### PR TITLE
bh.sh patch #1

### DIFF
--- a/bh.sh
+++ b/bh.sh
@@ -4,7 +4,7 @@
 # 1. Sanity check for the presence of a battery.
 bh_data=$(ioreg -rc AppleSmartBattery)
 if [ "$bh_data" = "" ];
-    then echo 'No battery found, exiting.'; return 1;
+    then echo 'No battery found, exiting.'; return 0;
 fi
 
 # 2. Retrieve battery status.


### PR DESCRIPTION
Changed the no battery exit code to 0 to avoid breaking program flow; it is not an error to detect no battery (iMacs, etc.)
TODO: send an Info line when no battery detected.